### PR TITLE
chore: update project name in cargo manifest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320cfe77175da3a483efed4bc0adc1968ca050b098ce4f2f1c13a56626128790"
 
 [[package]]
+name = "nixbom"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,17 +163,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "spdnix"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "clap",
- "serde",
- "serde_derive",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "spdnix"
+name = "nixbom"
 version = "0.1.0"
 edition = "2018"
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -299,7 +299,7 @@ impl SpdxSchema {
 }
 
 fn main() -> Result<(), Error> {
-    let matches = App::new("SPDNix")
+    let matches = App::new("nixbom")
         .version("0.1")
         .author("Michael Lieberman and Jack Kelly")
         .arg(


### PR DESCRIPTION
Looks like the project was renamed at some point, but the name in the `Cargo.toml` was never updated.