### PR TITLE
feat: show recursive derivations by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -124,12 +124,14 @@ fn get_derivation_bytes(file: &str, is_expression: bool) -> Result<Vec<u8>, Erro
     let output = if is_expression {
         Command::new("nix")
             .arg("show-derivation")
+            .arg("-r")
             .arg("-f")
             .arg(file)
             .output()
     } else {
         Command::new("nix")
             .arg("show-derivation")
+            .arg("-r")
             .arg(file)
             .output()
     }?;


### PR DESCRIPTION
Since the program is generating a SBOM, doesn't it make more sense to get the full list of dependencies by default?
@mlieberman85 let me know what you think. I'm open to adding a new CLI arg to toggle that behavior as well.